### PR TITLE
Rename design_system GitHub team to design-system in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @preply/design_system
+* @preply/design-system


### PR DESCRIPTION
## Summary
- Renames the `@preply/design_system` GitHub team reference to `@preply/design-system` in `.github/CODEOWNERS` to match the updated team name.

## Test plan
- [x] Verified the only GitHub team reference (`@preply/design_system`) is in `.github/CODEOWNERS`
- [x] Confirmed other `design_system` occurrences (Datadog metrics, test data) are not GitHub team names and should remain unchanged
- [ ] After merge, verify CODEOWNERS properly resolves to the `@preply/design-system` team